### PR TITLE
fix: use first UTF-8 byte to determine length of a character

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -8,12 +8,15 @@ import subprocess
 from pathlib import Path
 
 @pytest.mark.parametrize("case", (
-  pytest.param("utf-8.txt", marks=pytest.mark.xfail(strict=True)),
+  pytest.param("utf-8.txt",
+               marks=pytest.mark.xfail(strict=(platform.system() == "Linux"))),
   "utf-8_1.txt",
-  pytest.param("utf-8_2.txt", marks=pytest.mark.xfail(strict=True)),
-  pytest.param("utf-8_3.txt", marks=pytest.mark.xfail(strict=True)),
-  pytest.param("utf-8_4.txt", marks=pytest.mark.xfail(strict=True)),
-  pytest.param("utf-8_5.txt", marks=pytest.mark.xfail(strict=True)),
+  "utf-8_2.txt",
+  "utf-8_3.txt",
+  pytest.param("utf-8_4.txt",
+               marks=pytest.mark.xfail(strict=(platform.system() == "Linux"))),
+  pytest.param("utf-8_5.txt",
+               marks=pytest.mark.xfail(strict=(platform.system() == "Linux"))),
   pytest.param("utf-8_6.txt",
                marks=pytest.mark.xfail(strict=(platform.system() == "Linux")))))
 def test_utf8(case: str):


### PR DESCRIPTION
The UTF-8 decoding logic was using the last byte read to determine the length of
the current character being decoded. This meant that the only characters it
could successfully decode were 1-byte and 4-byte UTF-8. Characters of other
lengths that have 0b10-prefixed continuation bytes would be incorrectly
interpreted as meaning the character was 4 bytes long.