### PR TITLE
treat all SGR resets for unsupported modes as no-ops

### DIFF
--- a/libvimcat/src/term.c
+++ b/libvimcat/src/term.c
@@ -435,11 +435,18 @@ static int process_m(term_t *t, size_t index, bool is_default, size_t entry) {
     break;
 
   case 22:
-  case 23:
     t->style.bold = false;
     break;
   case 24:
     t->style.underline = false;
+    break;
+
+  // treat reset of features we do not support as a no-op
+  case 23: // reset italic
+  case 25: // reset blinking
+  case 27: // reset inverse/reverse
+  case 28: // reset hidden/invisible
+  case 29: // reset strikethrough
     break;
 
   case 30 ... 37:

--- a/test/tests.py
+++ b/test/tests.py
@@ -2,14 +2,20 @@
 Vimcat test suite
 """
 
+import platform
 import pytest
 import subprocess
 from pathlib import Path
 
-@pytest.mark.parametrize("case", ("utf-8.txt", "utf-8_1.txt", "utf-8_2.txt",
-                                  "utf-8_3.txt", "utf-8_4.txt", "utf-8_5.txt",
-                                  "utf-8_6.txt"))
-@pytest.mark.xfail(strict=True)
+@pytest.mark.parametrize("case", (
+  pytest.param("utf-8.txt", marks=pytest.mark.xfail(strict=True)),
+  "utf-8_1.txt",
+  pytest.param("utf-8_2.txt", marks=pytest.mark.xfail(strict=True)),
+  pytest.param("utf-8_3.txt", marks=pytest.mark.xfail(strict=True)),
+  pytest.param("utf-8_4.txt", marks=pytest.mark.xfail(strict=True)),
+  pytest.param("utf-8_5.txt", marks=pytest.mark.xfail(strict=True)),
+  pytest.param("utf-8_6.txt",
+               marks=pytest.mark.xfail(strict=(platform.system() == "Linux")))))
 def test_utf8(case: str):
   """
   check `vimcat` can deal with UTF-8 characters of any length


### PR DESCRIPTION
The CI environments send `<esc>[27m` where local execution does not. We do not
support the mode this is resetting, so just treat this and other similar
sequences as things we can safely ignore.