### PR TITLE
guards on public header’s 'VIMCAT_API'

### DIFF
--- a/libvimcat/include/vimcat/vimcat.h
+++ b/libvimcat/include/vimcat/vimcat.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef VIMCAT_API
 #define VIMCAT_API __attribute__((visibility("hidden")))
+#endif
 
 #include <vimcat/debug.h>
 #include <vimcat/read.h>


### PR DESCRIPTION
I left these guards off when importing code from Clink as I could not think of
my rationale for previously including them. But of course they are there in case
an importing library wants to onwards export libvimcat.