### PR TITLE
remove stub of support for combining marks

### DIFF
--- a/libvimcat/src/term.h
+++ b/libvimcat/src/term.h
@@ -9,6 +9,11 @@
 /// Only enough functionality to support the meaningful escape sequences that
 /// Vim emits is implemented.
 ///
+/// Unicode non-spacing combining marks are not accounted for. That is, if data
+/// being printed to the terminal contains a regular character followed by a
+/// non-spacing combining mark, these will be treated as two characters,
+/// advancing the cursor position by two.
+///
 /// TODO: replace this with libtsm?
 
 #pragma once


### PR DESCRIPTION
The original plan was to support an arbitrary number of non-spacing combining
marks by using the alternate heap-allocated buffer for a grapheme. However on
investigating this, I discovered there are ~2K non-spacing combining marks,
spread across multiple Unicode blocks, with sources disagreeing on which
characters belong in this category. The ground truth is the non-spacing mark
(`Mn`) category in the Unicode specification, but handling this correctly still
remains much more complex than I anticipated.

The cost of the implementation in terms of both complexity and runtime
performance overhead does not seem worth it. Getting this right would be
challenging and using a more principled UTF-8 approach like ICU would be a
significant change of design. Since the primary use case of `vimcat` is
highlighting program source code, non-spacing combining marks are unlikely to
appear. Furthermore the only infidelity is in the virtual terminal’s notion of
current position. That is, to observe a problem here your input source to the
terminal needs to either (1) have lines spanning more than Vim’s 10000 column
limit or (2) have ANSI sequences that jump backwards into lines containing such
marks. I have not observed Vim emit anything like (2).