### PR TITLE
namespace 'debug'

### DIFF
--- a/libvimcat/src/debug.c
+++ b/libvimcat/src/debug.c
@@ -3,11 +3,11 @@
 #include <stdio.h>
 #include <vimcat/debug.h>
 
-FILE *debug;
+FILE *vimcat_debug;
 
 FILE *vimcat_set_debug(FILE *stream) {
-  FILE *old = debug;
-  debug = stream;
+  FILE *old = vimcat_debug;
+  vimcat_debug = stream;
   return old;
 }
 

--- a/libvimcat/src/debug.h
+++ b/libvimcat/src/debug.h
@@ -5,17 +5,17 @@
 #include <stdio.h>
 #include <string.h>
 
-extern FILE *debug INTERNAL;
+extern FILE *vimcat_debug INTERNAL;
 
 /// emit a debug message
 #define DEBUG(args...)                                                         \
   do {                                                                         \
-    if (UNLIKELY(debug != NULL)) {                                             \
+    if (UNLIKELY(vimcat_debug != NULL)) {                                      \
       const char *name_ = strrchr(__FILE__, '/');                              \
-      flockfile(debug);                                                        \
-      fprintf(debug, "[VIMCAT] libvimcat/src%s:%d: ", name_, __LINE__);        \
-      fprintf(debug, args);                                                    \
-      fprintf(debug, "\n");                                                    \
-      funlockfile(debug);                                                      \
+      flockfile(vimcat_debug);                                                 \
+      fprintf(vimcat_debug, "[VIMCAT] libvimcat/src%s:%d: ", name_, __LINE__); \
+      fprintf(vimcat_debug, args);                                             \
+      fprintf(vimcat_debug, "\n");                                             \
+      funlockfile(vimcat_debug);                                               \
     }                                                                          \
   } while (0)


### PR DESCRIPTION
When building libvimcat as a shared library, the
`__attribute__((visibility("internal")))` annotation correctly made `debug`
invisible to external users. But when building as a static library, it has no
effect. The result of this is that users can get link errors if they have their
own `debug` symbol.

There are various workarounds to this (“pre-linking” on macOS,
`objcopy --localize-hidden`, …), but it seems simpler to just rename this
symbol to something more likely to be unique.