### PR TITLE
fix: skip 'termguicolors' tests when terminal does not support 256 colors

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -36,6 +36,9 @@ def test_colour(tmp_path: Path, colour: Optional[str], no_color: bool,
   `vimcat` should obey the user’s colour preferences
   """
 
+  if termguicolors and "256color" not in os.environ.get("TERM", ""):
+    pytest.skip("no 256-color support in this terminal")
+
   env = set_home(tmp_path)
   if no_color:
     env["NO_COLOR"] = "1"


### PR DESCRIPTION
If the current terminal does not report supporting 256-color mode (e.g. if you
are inside Screen/Tmux and your `$TERM` is “screen”), `set termguicolors`
results in unpredictable behaviour. Often the outcome is no syntax highlighting
at all.

Github: fixes #41 “NO_COLOR tests fail on Fedora 36”