### PR TITLE
tests: force correct colour sequences in 256-colour mode on all terminals

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -49,7 +49,10 @@ def test_colour(tmp_path: Path, colour: Optional[str], no_color: bool,
   with open(tmp_path / ".vimrc", "wt") as f:
     f.write(f"syntax on\nset t_Co={t_Co}\n")
     if termguicolors:
-      f.write("set termguicolors\n")
+      f.write("set termguicolors\n"
+              # we also need to teach Vim how to colourise
+              'let &t_8f = "\\<Esc>[38;2;%lu;%lu;%lum"\n'
+              'let &t_8b = "\\<Esc>[48;2;%lu;%lu;%lum"\n')
     if title:
       f.write("set title\n")
 


### PR DESCRIPTION
Vim explains its behaviour in `:help xterm-true-color`:

```
  Sometimes setting `termguicolors` is not enough and one has to set the `t_8f`
  and `t_8b` options explicitly. Default values of these options are
  "^[[38;2;%lu;%lu;%lum" and "^[[48;2;%lu;%lu;%lum" respectively, but it is only
  set when `$TERM` is `xterm`. Some terminals accept the same sequences, but
  with all semicolons replaced by colons (this is actually more compatible, but
  less widely supported):
    let &t_8f = "\<Esc>[38:2:%lu:%lu:%lum"
    let &t_8b = "\<Esc>[48:2:%lu:%lu:%lum"
```

This covers _what_ is happening, but not really _why_. Given there appears to be no way to use `termguicolors` with a non-xterm `$TERM` without setting `t_8f` and `t_8b`, it is not clear why they do not unconditionally default to the values quoted for xterm, especially as these are the portable ANSI-compatible sequences, as Vim hints at.

Updating this fixes the test suite under Tmux 3.3a, which begun setting `$TERM` to `tmux-256color`.

Github: fixes #41 “NO_COLOR tests fail on Fedora 36”