### PR TITLE
CI: migrate a Linux job to Github Actions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,17 +14,6 @@ task:
       install_script: python3 --version && pkg upgrade -y && pkg install -y cmake py311-pytest vim
       test_script: uname -sr && env cmake -B build -S . && cmake --build build && cmake --build build --target check && cmake --install build
 
-    - name: Linux, shared libraries
-      container:
-        image: gcc:14.1
-      environment:
-        DEBIAN_FRONTEND: noninteractive
-        CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined -fuse-ld=gold
-        LC_ALL: C.UTF-8
-        UBSAN_OPTIONS: print_stacktrace=1
-      install_script: apt-get update && apt-get install --no-install-recommends -y cmake python3-pytest vim xxd
-      test_script: uname -sr && env && cmake -DBUILD_SHARED_LIBS=ON -B build -S . && cmake --build build && cmake --build build --target check && cmake --install build
-
     - name: Linux, release build
       container:
         image: gcc:14.1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,17 +14,6 @@ task:
       install_script: python3 --version && pkg upgrade -y && pkg install -y cmake py311-pytest vim
       test_script: uname -sr && env cmake -B build -S . && cmake --build build && cmake --build build --target check && cmake --install build
 
-    - name: Linux
-      container:
-        image: gcc:14.1
-      environment:
-        DEBIAN_FRONTEND: noninteractive
-        CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined -fuse-ld=gold
-        LC_ALL: C.UTF-8
-        UBSAN_OPTIONS: print_stacktrace=1
-      install_script: apt-get update && apt-get install --no-install-recommends -y cmake python3-pytest vim xxd
-      test_script: uname -sr && env && cmake -B build -S . && cmake --build build && cmake --build build --target check && cmake --install build
-
     - name: Linux, shared libraries
       container:
         image: gcc:14.1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,15 +14,6 @@ task:
       install_script: python3 --version && pkg upgrade -y && pkg install -y cmake py311-pytest vim
       test_script: uname -sr && env cmake -B build -S . && cmake --build build && cmake --build build --target check && cmake --install build
 
-    - name: macOS
-      macos_instance:
-        image: ghcr.io/cirruslabs/macos-sonoma-base:latest
-      environment:
-        CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined
-        UBSAN_OPTIONS: print_stacktrace=1
-      install_script: brew update && brew install python3 && python3 -m pip install --break-system-packages pytest
-      test_script: uname -sr && env && cmake -B build -S . && cmake --build build && cmake --build build --target check && sudo cmake --install build
-
     - name: clang-format
       container:
         image: silkeh/clang:15

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,9 +13,3 @@ task:
         UBSAN_OPTIONS: print_stacktrace=1
       install_script: python3 --version && pkg upgrade -y && pkg install -y cmake py311-pytest vim
       test_script: uname -sr && env cmake -B build -S . && cmake --build build && cmake --build build --target check && cmake --install build
-
-    - name: clang-format
-      container:
-        image: silkeh/clang:15
-      install_script: apt-get update && apt-get install --no-install-recommends -y git
-      test_script: git ls-files -z '**/*.c' '**/*.h' | xargs -0 -- clang-format --dry-run --style=file --Werror

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,17 +14,6 @@ task:
       install_script: python3 --version && pkg upgrade -y && pkg install -y cmake py311-pytest vim
       test_script: uname -sr && env cmake -B build -S . && cmake --build build && cmake --build build --target check && cmake --install build
 
-    - name: Linux, release build
-      container:
-        image: gcc:14.1
-      environment:
-        DEBIAN_FRONTEND: noninteractive
-        CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=undefined -fuse-ld=gold
-        LC_ALL: C.UTF-8
-        UBSAN_OPTIONS: print_stacktrace=1
-      install_script: apt-get update && apt-get install --no-install-recommends -y cmake python3-pytest vim xxd
-      test_script: uname -sr && env && cmake -DCMAKE_BUILD_TYPE=Release -B build -S . && cmake --build build && cmake --build build --target check && cmake --install build
-
     - name: macOS
       macos_instance:
         image: ghcr.io/cirruslabs/macos-sonoma-base:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,23 @@ jobs:
       - run: cmake --build build
       - run: cmake --build build --target check
       - run: sudo cmake --install build
+
+  linux_release:
+    name: Linux, release build
+    runs-on: ubuntu-24.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
+      UBSAN_OPTIONS: print_stacktrace=1
+    steps:
+      - run: uname -rms
+      - run: python3 --version
+      - run: sudo apt-get update
+      - run: sudo apt-get install --no-install-recommends -y python3-pytest vim xxd
+      - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+      - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
+      - run: cd wd && git fetch -- origin ${{ github.event.pull_request.head.sha }} && git checkout FETCH_HEAD
+      - run: cmake -DCMAKE_BUILD_TYPE=Release -B build -S wd
+      - run: cmake --build build
+      - run: cmake --build build --target check
+      - run: sudo cmake --install build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Github Actions CI
+permissions: {}
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-24.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
+      UBSAN_OPTIONS: print_stacktrace=1
+    steps:
+      - run: uname -rms
+      - run: python3 --version
+      - run: sudo apt-get update
+      - run: sudo apt-get install --no-install-recommends -y python3-pytest vim xxd
+      - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+      - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
+      - run: cd wd && git fetch -- origin ${{ github.event.pull_request.head.sha }} && git checkout FETCH_HEAD
+      - run: cmake -B build -S wd
+      - run: cmake --build build
+      - run: cmake --build build --target check
+      - run: sudo cmake --install build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,13 @@ jobs:
       - run: cmake --build build
       - run: cmake --build build --target check
       - run: sudo cmake --install build
+
+  clang_format:
+    name: clang-format
+    runs-on: ubuntu-22.04
+    steps:
+      - run: uname -rms
+      - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+      - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
+      - run: cd wd && git fetch -- origin ${{ github.event.pull_request.head.sha }} && git checkout FETCH_HEAD
+      - run: cd wd && git ls-files -z '**/*.c' '**/*.h' | xargs -0 -- clang-format-15 --dry-run --style=file --Werror

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,21 @@ jobs:
       - run: cmake --build build
       - run: cmake --build build --target check
       - run: sudo cmake --install build
+
+  macos:
+    name: macOS
+    runs-on: macos-26-intel
+    env:
+      CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
+      UBSAN_OPTIONS: print_stacktrace=1
+    steps:
+      - run: uname -rms
+      - run: python3 --version
+      - run: env PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install pytest
+      - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+      - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
+      - run: cd wd && git fetch -- origin ${{ github.event.pull_request.head.sha }} && git checkout FETCH_HEAD
+      - run: cmake -B build -S wd
+      - run: cmake --build build
+      - run: cmake --build build --target check
+      - run: sudo cmake --install build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,23 @@ jobs:
       - run: cmake --build build
       - run: cmake --build build --target check
       - run: sudo cmake --install build
+
+  linux_shared:
+    name: Linux, shared libraries
+    runs-on: ubuntu-24.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      CFLAGS: -Werror -g -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined
+      UBSAN_OPTIONS: print_stacktrace=1
+    steps:
+      - run: uname -rms
+      - run: python3 --version
+      - run: sudo apt-get update
+      - run: sudo apt-get install --no-install-recommends -y python3-pytest vim xxd
+      - run: echo "cloning ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+      - run: git clone --no-checkout -- ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} wd
+      - run: cd wd && git fetch -- origin ${{ github.event.pull_request.head.sha }} && git checkout FETCH_HEAD
+      - run: cmake -DBUILD_SHARED_LIBS=ON -B build -S wd
+      - run: cmake --build build
+      - run: cmake --build build --target check
+      - run: sudo cmake --install build


### PR DESCRIPTION
Cirrus CI is being shutdown:¹

> Cirrus CI will shut down effective Monday, June 1, 2026.

So we need to migrate to something else. The best option at present seems to be Github Actions. This change effectively downgrades the compiler in use GCC 14.1 → GCC 13.2, but this seems acceptable.

¹ https://cirruslabs.org/